### PR TITLE
Daemoset yaml to capture dns packets from specific compartment.

### DIFF
--- a/scripts/captureDnsPackets/README.md
+++ b/scripts/captureDnsPackets/README.md
@@ -1,0 +1,30 @@
+# Capture DNS Packets
+
+> This yaml spawns hostprocess daemonset containers in every node once created. The script inside the container will start pktmon capture for DNS packets originating from every pod with prefix mentioned in powershell variable $podPrefix [Eg: "tcp-server"]
+
+## Start DNS Packet Capture
+
+Update the $podPrefix in StartDnsPktCapture2019.yaml with right values.
+```
+Line: 28   $podPrefix = "DnsPinger"
+```
+Start pktmon by creating daemon set: StartDnsPktCapture2019.yaml.
+```
+kubectl create -f .\StartDnsPktCapture2019.yaml
+```
+Keep the containers running less than 5 hours.
+
+## Stop DNS Packet Capture
+
+Once the issue is reproduced or pktmon running time exceeds 5 hours, stop pktmon by creating daemon set: StopDnsPktCapture2019.yaml and wait for 5 minutes.
+```
+kubectl create -f .\StopDnsPktCapture2019.yaml
+```
+Packet capture will be generated in “C:\pktmonLogs” directory of each node after 5 minutes. Copy the capture logs out of the node.
+
+## Delete DNS capture daemon sets
+Once the logs are copied, delete all the dns capture daemon sets.
+```
+kubectl delete -f .\StartDnsPktCapture2019.yaml
+kubectl delete -f .\StopDnsPktCapture2019.yaml
+```

--- a/scripts/captureDnsPackets/StartDnsPktCapture2019.yaml
+++ b/scripts/captureDnsPackets/StartDnsPktCapture2019.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: start-dns-pkt-capture
+  labels:
+    app: start-dns-pkt-capture
+spec:
+  selector:
+    matchLabels:
+      name: start-dns-pkt-capture
+  template:
+    metadata:
+      labels:
+        name: start-dns-pkt-capture
+    spec:
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\SYSTEM"
+      hostNetwork: true
+      containers:
+      - name: start-dns-pkt-capture
+        image: mcr.microsoft.com/windows/nanoserver:1809
+        command:
+        - powershell.exe
+        - -command
+        - |
+            $podPrefix = "tcp-server"
+            $pktmonLogs = "C:\pktmonLogs"
+
+            Write-Host "Stop pktmon if running..."
+            pktmon stop
+
+            $pods = (crictl pods -o json | ConvertFrom-Json).items
+            $podIPs = @()
+            $macAddrs = @()
+
+            foreach($pod in $pods) {
+              if($pod.metadata.name -like "$podPrefix*") { 
+                $podInspect = (crictl inspectp $pod.id | ConvertFrom-Json)
+                $podIP = $podInspect.status.network.ip
+                $podIPs += $podIP
+                $macAddrs += (Get-HnsEndpoint | where IPAddress -EQ $podIP).MacAddress
+              } 
+            }
+
+            if(($macAddrs).Count -Eq 0) {
+              Write-Host "No matching pods. No mac addresses found..."
+              While($true) {
+                Start-Sleep -Seconds 60
+              }
+              return
+            }
+
+            Write-Host "POD IPS : $podIPs"
+            Write-Host "MAC ADDRESSES : $macAddrs"
+
+            $compIds = ""
+
+            foreach($mac in $macAddrs) {
+              $grepped = pktmon list | Select-String $mac
+              $compId = $grepped.ToString().Trim().Split(" ")[0]
+              if($compId -ne "") {
+                if($compIds -eq "") {
+                  $compIds = $compId
+                } else {
+                  $compIds += ","
+                  $compIds += $compId
+                }
+              }
+            }
+
+            if($compIds -Eq "") {
+              Write-Host "No matching pods. No component IDs found..."
+              While($true) {
+                Start-Sleep -Seconds 60
+              }
+              return
+            }
+
+            Write-Host "COMPONENT IDS : $compIds"
+
+            Write-Host "Removing all pktmon filters if anything existing..."
+            pktmon filter remove
+
+            Write-Host "Create DNS Port filter..."
+            pktmon filter add DNSFilter -p 53
+
+            Write-Host "Create a directory for pktmon logs..."
+            remove-item -Recurse -Force $pktmonLogs -ErrorAction Ignore
+            mkdir $pktmonLogs
+            Set-Location $pktmonLogs
+
+            Write-Host "Start pktmon. Command : [pktmon start -c --comp $compIds --pkt-size 0 -m multi-file] ..."
+            pktmon start -c --comp $compIds --pkt-size 0 -m multi-file
+
+            Write-Host "Logs will be available in $pktmonLogs"
+
+            While($true) {
+              Start-Sleep -Seconds 21600
+              Write-Host "Stop pktmon if running..."
+              pktmon stop
+            }
+
+        securityContext:
+          privileged: true
+      nodeSelector:
+        kubernetes.azure.com/os-sku: Windows2019

--- a/scripts/captureDnsPackets/StopDnsPktCapture2019.yaml
+++ b/scripts/captureDnsPackets/StopDnsPktCapture2019.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: stop-dns-pkt-capture
+  labels:
+    app: stop-dns-pkt-capture
+spec:
+  selector:
+    matchLabels:
+      name: stop-dns-pkt-capture
+  template:
+    metadata:
+      labels:
+        name: stop-dns-pkt-capture
+    spec:
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\SYSTEM"
+      hostNetwork: true
+      containers:
+      - name: stop-dns-pkt-capture
+        image: mcr.microsoft.com/windows/nanoserver:1809
+        command:
+        - powershell.exe
+        - -command
+        - |
+            $pktmonLogs = "C:\pktmonLogs"
+
+            Write-Host "Stop pktmon if running..."
+            pktmon stop
+
+            Write-Host "Pktmon stopped. Logs will be available in : $pktmonLogs ..."
+            While($true) {
+              Start-Sleep -Seconds 600
+            }
+
+        securityContext:
+          privileged: true
+      nodeSelector:
+        kubernetes.azure.com/os-sku: Windows2019


### PR DESCRIPTION
This yaml will create and run host process daemonsets for Windows Server 2019 nodes. The daemonset will run a script in each node. The work of the script is to find the pktmon component id for each pod specified by pod name prefix and run pktmon for those pods with DNS port (53) filter.
It also checks the DNS policy count in the nodes and logs if there is a missing DNS policy.
The pktmon capture can be stopped by creating a new yaml StopDnsPktCapture2019.yaml